### PR TITLE
fix: Remove link for coordinationKit

### DIFF
--- a/common-util/data/products.json
+++ b/common-util/data/products.json
@@ -1,4 +1,5 @@
-[{
+[
+  {
     "id": "open-autonomy",
     "category": "core",
     "title": "Open Autonomy",
@@ -44,7 +45,7 @@
     "title": "CoordinationKit",
     "description": "Coordinate DAO contributors autonomously",
     "liveLink": {
-      "url": "https://contribute.autonolas.network",
+      "url": "",
       "external": false
     }
   },


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
* `CoordinationKit` won't be pointing to contribute website and the button will be disabled as shown in the video below 👇 

https://user-images.githubusercontent.com/22061815/229476104-2ca4ac4b-5ad8-4623-9a89-219d3f3f408a.mov


## Types of changes

What types of changes does your code introduce to `autonolas-website`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature enhancement (update to current feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Links are working as expected (internal and external links)
- [ ] Responsiveness maintained (mobile, Ipad & desktop)
- [ ] Sitemap: for dynamic pages, API is added to `/sitemapHelpers/dynamicPages.jsx`
- [ ] Meta tag added/updated
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I am making a pull request against the `staging` branch (left side). Also you should start your branch off our `staging`.

## Further comments

Write here any other comment about the release, if any.
