### PR TITLE
feat: W26 Fix "learn and build" responsiveness for Ipad

### DIFF
--- a/components/HomePage/7StartBuilding/index.jsx
+++ b/components/HomePage/7StartBuilding/index.jsx
@@ -21,7 +21,7 @@ const getContent = list => list.map(
     },
     index,
   ) => (
-    <Col lg={8} sm={24} xs={24} key={`start-building-${imageUrl}`}>
+    <Col lg={8} md={12} sm={24} xs={24} key={`start-building-${imageUrl}`}>
       <div key={imageUrl} className={`column column-${index + 1}`}>
         <div className="img-container-custom">
           <Image

--- a/components/HomePage/7StartBuilding/styles.jsx
+++ b/components/HomePage/7StartBuilding/styles.jsx
@@ -63,6 +63,12 @@ export const Container = styled(C)`
     }
   }
 
+  ${MEDIA_QUERY.tabletL} {
+    &::after {
+      display: none;
+    }
+  }
+
   ${MEDIA_QUERY.tablet} {
     gap: 0 3rem;
     .column {
@@ -95,9 +101,6 @@ export const Container = styled(C)`
       .action-btn .btn {
         font-size: 16px;
       }
-    }
-    &::after {
-      display: none;
     }
   }
 `;


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.



## Types of changes

* Learn and build should be responsive in Ipad, mobile and laptop

https://github.com/valory-xyz/autonolas-website/assets/22061815/29d73ddb-f7eb-49fe-b784-a9717541f8ce


What types of changes does your code introduce to `autonolas-website`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Feature enhancement (update to current feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Links are working as expected (internal and external links)
- [x] Responsiveness maintained (mobile, Ipad & desktop)
- [ ] Sitemap: for dynamic pages, API is added to `/sitemapHelpers/dynamicPages.jsx`
- [ ] Meta tag added/updated
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added the necessary documentation (if appropriate)

## Further comments

Write here any other comment about the release, if any.
